### PR TITLE
Vermyndax add kms support for firehose

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -175,6 +175,7 @@ resource "aws_kinesis_firehose_delivery_stream" "extended_s3_stream" {
         buffer_interval = "${var.s3_buffer_interval}"
         compression_format = "${var.s3_compression_format}"
         prefix = "${var.s3_prefix}"
+        kms_key_arn = "${var.s3_kms_key_arn}"
         cloudwatch_logging_options {
             enabled = "${var.s3_cloudwatch_logging_enabled}"
             log_group_name = "${aws_cloudwatch_log_group.s3_log_group.name}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,3 +1,9 @@
+resource "aws_kms_key" "s3_logging_kms_key" {
+    count = "${var.s3_kms_key_arn != "" ? 1 : 0}"
+
+    description = "S3 Logging KMS Key - Created by Terraform"
+}
+
 resource "aws_elasticsearch_domain" "elasticsearch" {
   domain_name = "${var.es_domain_name}"
   elasticsearch_version = "${var.es_version}"
@@ -175,7 +181,7 @@ resource "aws_kinesis_firehose_delivery_stream" "extended_s3_stream" {
         buffer_interval = "${var.s3_buffer_interval}"
         compression_format = "${var.s3_compression_format}"
         prefix = "${var.s3_prefix}"
-        kms_key_arn = "${var.s3_kms_key_arn}"
+        kms_key_arn = "${var.s3_kms_key_arn != "" ? var.s3_kms_key_arn : aws_kms_key.s3_logging_kms_key.arn}"
         cloudwatch_logging_options {
             enabled = "${var.s3_cloudwatch_logging_enabled}"
             log_group_name = "${aws_cloudwatch_log_group.s3_log_group.name}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 resource "aws_kms_key" "s3_logging_kms_key" {
-    count = "${var.s3_kms_key_arn != "" ? 1 : 0}"
+    count = "${var.s3_kms_key_arn == "" ? 1 : 0}"
 
     description = "S3 Logging KMS Key - Created by Terraform"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,6 +7,7 @@ variable "es_kinesis_delivery_stream" {
 variable "s3_kms_key_arn" {
     type = "string"
     description = "KMS Key ARN used to encrypt data within S3 bucket. The key must already exist within the account."
+    default = ""
 }
 variable "aws_region" {
     default = "us-east-1"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,6 +4,10 @@ variable "s3_logging_bucket_name" {
 variable "es_kinesis_delivery_stream" {
     type = "string"
 }
+variable "s3_kms_key_arn" {
+    type = "string"
+    description = "KMS Key ARN used to encrypt data within S3 bucket. The key must already exist within the account."
+}
 variable "aws_region" {
     default = "us-east-1"
 }


### PR DESCRIPTION
Support KMS encryption of the S3 bucket with an optional KMS key ARN. If it's not provided, terraform will create a KMS key and use it.