### PR TITLE
Vermyndax temp remove elasticsearch

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,48 +4,48 @@ resource "aws_kms_key" "s3_logging_kms_key" {
     description = "S3 Logging KMS Key - Created by Terraform"
 }
 
-resource "aws_elasticsearch_domain" "elasticsearch" {
-  domain_name = "${var.es_domain_name}"
-  elasticsearch_version = "${var.es_version}"
+# resource "aws_elasticsearch_domain" "elasticsearch" {
+#   domain_name = "${var.es_domain_name}"
+#   elasticsearch_version = "${var.es_version}"
   
-  cluster_config {
-      dedicated_master_enabled = "${var.es_dedicated_master_enabled}"
-      instance_type = "${var.es_instance_type}"
-      instance_count = "${var.es_instance_count}"
-      zone_awareness_enabled = "${var.es_zone_awareness_enabled}"
-      dedicated_master_type = "${var.es_dedicated_master_instance_type}"
-      dedicated_master_count = "${var.es_dedicated_master_count}"
-  }
+#   cluster_config {
+#       dedicated_master_enabled = "${var.es_dedicated_master_enabled}"
+#       instance_type = "${var.es_instance_type}"
+#       instance_count = "${var.es_instance_count}"
+#       zone_awareness_enabled = "${var.es_zone_awareness_enabled}"
+#       dedicated_master_type = "${var.es_dedicated_master_instance_type}"
+#       dedicated_master_count = "${var.es_dedicated_master_count}"
+#   }
 
-  advanced_options {
-      "rest.action.multi.allow_explicit_index" = "${var.es_advanced_allow_explicit_index}"
-  }
+#   advanced_options {
+#       "rest.action.multi.allow_explicit_index" = "${var.es_advanced_allow_explicit_index}"
+#   }
 
-  ebs_options {
-      ebs_enabled = "${var.es_ebs_enabled}"
-      iops = "${var.es_ebs_iops}"
-      volume_size = "${var.es_ebs_volume_size}"
-      volume_type = "${var.es_ebs_volume_type}"
-  }
+#   ebs_options {
+#       ebs_enabled = "${var.es_ebs_enabled}"
+#       iops = "${var.es_ebs_iops}"
+#       volume_size = "${var.es_ebs_volume_size}"
+#       volume_type = "${var.es_ebs_volume_type}"
+#   }
 
-  snapshot_options {
-      automated_snapshot_start_hour = "${var.es_snapshot_start_hour}"
-  }
+#   snapshot_options {
+#       automated_snapshot_start_hour = "${var.es_snapshot_start_hour}"
+#   }
 
-    access_policies = <<CONFIG
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": "es:*",
-            "Principal": "*",
-            "Effect": "Allow",
-            "Resource": "*"
-        }
-    ]
-}
-CONFIG
-}
+#     access_policies = <<CONFIG
+# {
+#     "Version": "2012-10-17",
+#     "Statement": [
+#         {
+#             "Action": "es:*",
+#             "Principal": "*",
+#             "Effect": "Allow",
+#             "Resource": "*"
+#         }
+#     ]
+# }
+# CONFIG
+# }
 
 # IAM roles and policies for this stack
 
@@ -59,9 +59,9 @@ data "template_file" "firehose_assume_role_policy" {
   template = "${file("${path.module}/policies/firehose_assume_role.json")}"
 }
 
-data "template_file" "elasticsearch_policy" {
-  template = "${file("${path.module}/policies/elasticsearch_policy.json")}"
-}
+# data "template_file" "elasticsearch_policy" {
+#   template = "${file("${path.module}/policies/elasticsearch_policy.json")}"
+# }
 
 # S3
 resource "aws_iam_role" "s3_delivery_role" {
@@ -87,92 +87,95 @@ resource "aws_iam_policy" "s3_log_bucket_iam_policy" {
 }
 
 # ElasticSearch
-resource "aws_iam_role" "elasticsearch_role" {
-    name = "${var.elasticsearch_role_name}"
-    assume_role_policy = "${data.template_file.ec2_assume_role_policy.rendered}"
-}
+# resource "aws_iam_role" "elasticsearch_role" {
+#     name = "${var.elasticsearch_role_name}"
+#     assume_role_policy = "${data.template_file.ec2_assume_role_policy.rendered}"
+# }
 
-resource "aws_iam_instance_profile" "elasticsearch_instance_profile" {
-  name  = "${var.elasticsearch_role_name}-instance-profile"
-  role = "${aws_iam_role.elasticsearch_role.name}"
-}
+# resource "aws_iam_instance_profile" "elasticsearch_instance_profile" {
+#   name  = "${var.elasticsearch_role_name}-instance-profile"
+#   role = "${aws_iam_role.elasticsearch_role.name}"
+# }
 
-resource "aws_iam_policy" "elasticsearch_policy" {
-    name = "${var.elasticsearch_role_policy_name}"
-    policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "cloudwatch:GetMetricStatistics",
-        "cloudwatch:ListMetrics",
-        "cloudwatch:PutMetricAlarm",
-        "cloudwatch:PutMetricData",
-        "cloudwatch:SetAlarmState"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
-EOF
-}
+# resource "aws_iam_policy" "elasticsearch_policy" {
+#     name = "${var.elasticsearch_role_policy_name}"
+#     policy = <<EOF
+# {
+#   "Version": "2012-10-17",
+#   "Statement": [
+#     {
+#       "Action": [
+#         "cloudwatch:GetMetricStatistics",
+#         "cloudwatch:ListMetrics",
+#         "cloudwatch:PutMetricAlarm",
+#         "cloudwatch:PutMetricData",
+#         "cloudwatch:SetAlarmState"
+#       ],
+#       "Effect": "Allow",
+#       "Resource": "*"
+#     }
+#   ]
+# }
+# EOF
+# }
 
-resource "aws_iam_role_policy_attachment" "elasticsearch_policy_attach" {
-    role = "${aws_iam_role.elasticsearch_role.name}"
-    policy_arn = "${aws_iam_policy.elasticsearch_policy.arn}"
-}
+# resource "aws_iam_role_policy_attachment" "elasticsearch_policy_attach" {
+#     role = "${aws_iam_role.elasticsearch_role.name}"
+#     policy_arn = "${aws_iam_policy.elasticsearch_policy.arn}"
+# }
 
-resource "aws_iam_role_policy_attachment" "es_full_access" {
-    role = "${aws_iam_role.elasticsearch_role.name}"
-    policy_arn = "arn:aws:iam::aws:policy/AmazonESFullAccess"
-}
+# resource "aws_iam_role_policy_attachment" "es_full_access" {
+#     role = "${aws_iam_role.elasticsearch_role.name}"
+#     policy_arn = "arn:aws:iam::aws:policy/AmazonESFullAccess"
+# }
 
 resource "aws_iam_role_policy_attachment" "s3_full_access" {
     role = "${aws_iam_role.elasticsearch_role.name}"
     policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
 }
+
 resource "aws_iam_role_policy_attachment" "es_kinesisfirehouse_full_access" {
     role = "${aws_iam_role.elasticsearch_role.name}"
     policy_arn = "arn:aws:iam::aws:policy/AmazonKinesisFirehoseFullAccess"
 }
-resource "aws_iam_role_policy_attachment" "es_cloudwatch_full_access" {
-    role = "${aws_iam_role.elasticsearch_role.name}"
-    policy_arn = "arn:aws:iam::aws:policy/CloudWatchFullAccess"
-}
 
-resource "aws_iam_role" "elasticsearch_delivery_role" {
-    name = "${var.es_delivery_role_name}"
-    assume_role_policy = "${data.template_file.firehose_assume_role_policy.rendered}"
-}
+# resource "aws_iam_role_policy_attachment" "es_cloudwatch_full_access" {
+#     role = "${aws_iam_role.elasticsearch_role.name}"
+#     policy_arn = "arn:aws:iam::aws:policy/CloudWatchFullAccess"
+# }
 
-resource "aws_iam_role_policy_attachment" "es_delivery_full_access" {
-    role = "${aws_iam_role.elasticsearch_delivery_role.name}"
-    policy_arn = "arn:aws:iam::aws:policy/AmazonESFullAccess"
-}
+# resource "aws_iam_role" "elasticsearch_delivery_role" {
+#     name = "${var.es_delivery_role_name}"
+#     assume_role_policy = "${data.template_file.firehose_assume_role_policy.rendered}"
+# }
+
+# resource "aws_iam_role_policy_attachment" "es_delivery_full_access" {
+#     role = "${aws_iam_role.elasticsearch_delivery_role.name}"
+#     policy_arn = "arn:aws:iam::aws:policy/AmazonESFullAccess"
+# }
 
 resource "aws_kinesis_firehose_delivery_stream" "extended_s3_stream" {
     name = "${var.es_kinesis_delivery_stream}"
-    destination = "elasticsearch"
+    destination = "s3"
+    # destination = "elasticsearch"
     
-    elasticsearch_configuration {
-        buffering_interval = "${var.es_buffering_interval}"
-        buffering_size = "${var.es_buffering_size}"
-        cloudwatch_logging_options {
-            enabled = "${var.es_cloudwatch_logging_enabled}"
-            log_group_name = "${aws_cloudwatch_log_group.es_log_group.name}"
-            log_stream_name = "${aws_cloudwatch_log_stream.es_log_stream.name}"
-        }
-        domain_arn = "${aws_elasticsearch_domain.elasticsearch.arn}"
-        role_arn = "${aws_iam_role.elasticsearch_delivery_role.arn}"
-        index_name = "${var.es_index_name}"
-        type_name = "${var.es_type_name}"
-        index_rotation_period = "${var.es_index_rotation_period}"
-        retry_duration = "${var.es_retry_duration}"
-        role_arn = "${aws_iam_role.elasticsearch_delivery_role.arn}"
-        s3_backup_mode = "${var.es_s3_backup_mode}"
-    }
+    # elasticsearch_configuration {
+    #     buffering_interval = "${var.es_buffering_interval}"
+    #     buffering_size = "${var.es_buffering_size}"
+    #     cloudwatch_logging_options {
+    #         enabled = "${var.es_cloudwatch_logging_enabled}"
+    #         log_group_name = "${aws_cloudwatch_log_group.es_log_group.name}"
+    #         log_stream_name = "${aws_cloudwatch_log_stream.es_log_stream.name}"
+    #     }
+    #     domain_arn = "${aws_elasticsearch_domain.elasticsearch.arn}"
+    #     role_arn = "${aws_iam_role.elasticsearch_delivery_role.arn}"
+    #     index_name = "${var.es_index_name}"
+    #     type_name = "${var.es_type_name}"
+    #     index_rotation_period = "${var.es_index_rotation_period}"
+    #     retry_duration = "${var.es_retry_duration}"
+    #     role_arn = "${aws_iam_role.elasticsearch_delivery_role.arn}"
+    #     s3_backup_mode = "${var.es_s3_backup_mode}"
+    # }
     
     s3_configuration {
         role_arn = "${aws_iam_role.s3_delivery_role.arn}"
@@ -190,20 +193,20 @@ resource "aws_kinesis_firehose_delivery_stream" "extended_s3_stream" {
     }
 }
 
-resource "aws_cloudwatch_log_group" "es_log_group" {
-    name = "${var.es_log_group_name}"
-    retention_in_days = "${var.es_log_retention_in_days}"
-}
+# resource "aws_cloudwatch_log_group" "es_log_group" {
+#     name = "${var.es_log_group_name}"
+#     retention_in_days = "${var.es_log_retention_in_days}"
+# }
 
 resource "aws_cloudwatch_log_group" "s3_log_group" {
     name = "${var.s3_log_group_name}"
     retention_in_days = "${var.s3_log_retention_in_days}"
 }
 
-resource "aws_cloudwatch_log_stream" "es_log_stream" {
-    name = "${var.es_log_stream_name}"
-    log_group_name = "${aws_cloudwatch_log_group.es_log_group.name}"
-}
+# resource "aws_cloudwatch_log_stream" "es_log_stream" {
+#     name = "${var.es_log_stream_name}"
+#     log_group_name = "${aws_cloudwatch_log_group.es_log_group.name}"
+# }
 
 resource "aws_cloudwatch_log_stream" "s3_log_stream" {
     name = "${var.s3_log_stream_name}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -129,15 +129,15 @@ resource "aws_iam_policy" "s3_log_bucket_iam_policy" {
 #     policy_arn = "arn:aws:iam::aws:policy/AmazonESFullAccess"
 # }
 
-resource "aws_iam_role_policy_attachment" "s3_full_access" {
-    role = "${aws_iam_role.elasticsearch_role.name}"
-    policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
-}
+# resource "aws_iam_role_policy_attachment" "s3_full_access" {
+#     role = "${aws_iam_role.elasticsearch_role.name}"
+#     policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+# }
 
-resource "aws_iam_role_policy_attachment" "es_kinesisfirehouse_full_access" {
-    role = "${aws_iam_role.elasticsearch_role.name}"
-    policy_arn = "arn:aws:iam::aws:policy/AmazonKinesisFirehoseFullAccess"
-}
+# resource "aws_iam_role_policy_attachment" "es_kinesisfirehouse_full_access" {
+#     role = "${aws_iam_role.elasticsearch_role.name}"
+#     policy_arn = "arn:aws:iam::aws:policy/AmazonKinesisFirehoseFullAccess"
+# }
 
 # resource "aws_iam_role_policy_attachment" "es_cloudwatch_full_access" {
 #     role = "${aws_iam_role.elasticsearch_role.name}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -86,7 +86,6 @@ resource "aws_iam_policy" "s3_log_bucket_iam_policy" {
   policy = "${data.aws_iam_policy_document.s3_log_bucket_access.json}"
 }
 
-ElasticSearch
 resource "aws_iam_role" "ekk_role" {
     name = "${var.ekk_role_name}"
     assume_role_policy = "${data.template_file.ec2_assume_role_policy.rendered}"
@@ -120,8 +119,8 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "ekk_policy_attach" {
-    role = "${aws_iam_role.elasticsearch_role.name}"
-    policy_arn = "${aws_iam_policy.elasticsearch_policy.arn}"
+    role = "${aws_iam_role.ekk_role.name}"
+    policy_arn = "${aws_iam_policy.ekk_policy.arn}"
 }
 
 # resource "aws_iam_role_policy_attachment" "es_full_access" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -86,63 +86,63 @@ resource "aws_iam_policy" "s3_log_bucket_iam_policy" {
   policy = "${data.aws_iam_policy_document.s3_log_bucket_access.json}"
 }
 
-# ElasticSearch
-# resource "aws_iam_role" "elasticsearch_role" {
-#     name = "${var.elasticsearch_role_name}"
-#     assume_role_policy = "${data.template_file.ec2_assume_role_policy.rendered}"
-# }
+ElasticSearch
+resource "aws_iam_role" "ekk_role" {
+    name = "${var.ekk_role_name}"
+    assume_role_policy = "${data.template_file.ec2_assume_role_policy.rendered}"
+}
 
-# resource "aws_iam_instance_profile" "elasticsearch_instance_profile" {
-#   name  = "${var.elasticsearch_role_name}-instance-profile"
-#   role = "${aws_iam_role.elasticsearch_role.name}"
-# }
+resource "aws_iam_instance_profile" "ekk_instance_profile" {
+  name  = "${var.ekk_role_name}-instance-profile"
+  role = "${aws_iam_role.ekk_role.name}"
+}
 
-# resource "aws_iam_policy" "elasticsearch_policy" {
-#     name = "${var.elasticsearch_role_policy_name}"
-#     policy = <<EOF
-# {
-#   "Version": "2012-10-17",
-#   "Statement": [
-#     {
-#       "Action": [
-#         "cloudwatch:GetMetricStatistics",
-#         "cloudwatch:ListMetrics",
-#         "cloudwatch:PutMetricAlarm",
-#         "cloudwatch:PutMetricData",
-#         "cloudwatch:SetAlarmState"
-#       ],
-#       "Effect": "Allow",
-#       "Resource": "*"
-#     }
-#   ]
-# }
-# EOF
-# }
+resource "aws_iam_policy" "ekk_policy" {
+    name = "${var.ekk_role_policy_name}"
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "cloudwatch:GetMetricStatistics",
+        "cloudwatch:ListMetrics",
+        "cloudwatch:PutMetricAlarm",
+        "cloudwatch:PutMetricData",
+        "cloudwatch:SetAlarmState"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
 
-# resource "aws_iam_role_policy_attachment" "elasticsearch_policy_attach" {
-#     role = "${aws_iam_role.elasticsearch_role.name}"
-#     policy_arn = "${aws_iam_policy.elasticsearch_policy.arn}"
-# }
+resource "aws_iam_role_policy_attachment" "ekk_policy_attach" {
+    role = "${aws_iam_role.elasticsearch_role.name}"
+    policy_arn = "${aws_iam_policy.elasticsearch_policy.arn}"
+}
 
 # resource "aws_iam_role_policy_attachment" "es_full_access" {
 #     role = "${aws_iam_role.elasticsearch_role.name}"
 #     policy_arn = "arn:aws:iam::aws:policy/AmazonESFullAccess"
 # }
 
-# resource "aws_iam_role_policy_attachment" "s3_full_access" {
-#     role = "${aws_iam_role.elasticsearch_role.name}"
-#     policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
-# }
+resource "aws_iam_role_policy_attachment" "s3_full_access" {
+    role = "${aws_iam_role.ekk_role.name}"
+    policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}
 
-# resource "aws_iam_role_policy_attachment" "es_kinesisfirehouse_full_access" {
-#     role = "${aws_iam_role.elasticsearch_role.name}"
-#     policy_arn = "arn:aws:iam::aws:policy/AmazonKinesisFirehoseFullAccess"
-# }
+resource "aws_iam_role_policy_attachment" "kinesisfirehouse_full_access" {
+    role = "${aws_iam_role.ekk_role.name}"
+    policy_arn = "arn:aws:iam::aws:policy/AmazonKinesisFirehoseFullAccess"
+}
 
-# resource "aws_iam_role_policy_attachment" "es_cloudwatch_full_access" {
-#     role = "${aws_iam_role.elasticsearch_role.name}"
-#     policy_arn = "arn:aws:iam::aws:policy/CloudWatchFullAccess"
-# }
+resource "aws_iam_role_policy_attachment" "es_cloudwatch_full_access" {
+    role = "${aws_iam_role.ekk_role.name}"
+    policy_arn = "arn:aws:iam::aws:policy/CloudWatchFullAccess"
+}
 
 # resource "aws_iam_role" "elasticsearch_delivery_role" {
 #     name = "${var.es_delivery_role_name}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -155,7 +155,7 @@ resource "aws_iam_policy" "s3_log_bucket_iam_policy" {
 # }
 
 resource "aws_kinesis_firehose_delivery_stream" "extended_s3_stream" {
-    name = "${var.es_kinesis_delivery_stream}"
+    name = "${var.kinesis_delivery_stream}"
     destination = "s3"
     # destination = "elasticsearch"
     

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,10 +1,10 @@
-output "es_domain_arn" {
-    value = "${aws_elasticsearch_domain.elasticsearch.arn}"
-}
+# output "es_domain_arn" {
+#     value = "${aws_elasticsearch_domain.elasticsearch.arn}"
+# }
 
-output "es_domain_endpoint" {
-    value = "${aws_elasticsearch_domain.elasticsearch.endpoint}"
-}
+# output "es_domain_endpoint" {
+#     value = "${aws_elasticsearch_domain.elasticsearch.endpoint}"
+# }
 
 output "elasticsearch_instance_profile_id" {
     value = "${aws_iam_instance_profile.ekk_instance_profile.id}"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -6,6 +6,6 @@
 #     value = "${aws_elasticsearch_domain.elasticsearch.endpoint}"
 # }
 
-output "elasticsearch_instance_profile_id" {
+output "ekk_instance_profile_id" {
     value = "${aws_iam_instance_profile.ekk_instance_profile.id}"
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,11 +1,11 @@
-# output "es_domain_arn" {
-#     value = "${aws_elasticsearch_domain.elasticsearch.arn}"
-# }
+output "es_domain_arn" {
+    value = "${aws_elasticsearch_domain.elasticsearch.arn}"
+}
 
-# output "es_domain_endpoint" {
-#     value = "${aws_elasticsearch_domain.elasticsearch.endpoint}"
-# }
+output "es_domain_endpoint" {
+    value = "${aws_elasticsearch_domain.elasticsearch.endpoint}"
+}
 
-# output "elasticsearch_instance_profile_id" {
-#     value = "${aws_iam_instance_profile.elasticsearch_instance_profile.id}"
-# }
+output "elasticsearch_instance_profile_id" {
+    value = "${aws_iam_instance_profile.ekk_instance_profile.id}"
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,11 +1,11 @@
-output "es_domain_arn" {
-    value = "${aws_elasticsearch_domain.elasticsearch.arn}"
-}
+# output "es_domain_arn" {
+#     value = "${aws_elasticsearch_domain.elasticsearch.arn}"
+# }
 
-output "es_domain_endpoint" {
-    value = "${aws_elasticsearch_domain.elasticsearch.endpoint}"
-}
+# output "es_domain_endpoint" {
+#     value = "${aws_elasticsearch_domain.elasticsearch.endpoint}"
+# }
 
-output "elasticsearch_instance_profile_id" {
-    value = "${aws_iam_instance_profile.elasticsearch_instance_profile.id}"
-}
+# output "elasticsearch_instance_profile_id" {
+#     value = "${aws_iam_instance_profile.elasticsearch_instance_profile.id}"
+# }

--- a/terraform/test/ec2-test.tf
+++ b/terraform/test/ec2-test.tf
@@ -31,7 +31,7 @@ data "aws_ami" "ec2-linux" {
 resource "aws_instance" "stream_tester" {
   ami           = "${data.aws_ami.ec2-linux.id}"
   instance_type = "t2.micro"
-  # iam_instance_profile = "${module.ekk_stack.elasticsearch_instance_profile_id}"
+  iam_instance_profile = "${module.ekk_stack.ekk_instance_profile_id}"
 
   subnet_id = "${module.test_vpc.public_subnets[0]}"
   vpc_security_group_ids = ["${aws_security_group.main.id}"]

--- a/terraform/test/ec2-test.tf
+++ b/terraform/test/ec2-test.tf
@@ -1,14 +1,14 @@
 module "ekk_stack" {
   source = "../"
   s3_logging_bucket_name = "${var.s3_logging_bucket_name}"
-  es_kinesis_delivery_stream = "${var.es_kinesis_delivery_stream}"
+  kinesis_delivery_stream = "${var.kinesis_delivery_stream}"
 }
 
 data "template_file" "user_data_template" {
   template = "${file("${path.module}/files/ec2-test.tpl")}"
 
   vars {
-    deliverystream = "${var.es_kinesis_delivery_stream}"
+    deliverystream = "${var.kinesis_delivery_stream}"
   }
 }
 
@@ -31,7 +31,7 @@ data "aws_ami" "ec2-linux" {
 resource "aws_instance" "stream_tester" {
   ami           = "${data.aws_ami.ec2-linux.id}"
   instance_type = "t2.micro"
-  iam_instance_profile = "${module.ekk_stack.elasticsearch_instance_profile_id}"
+  # iam_instance_profile = "${module.ekk_stack.elasticsearch_instance_profile_id}"
 
   subnet_id = "${module.test_vpc.public_subnets[0]}"
   vpc_security_group_ids = ["${aws_security_group.main.id}"]

--- a/terraform/test/variables.tf
+++ b/terraform/test/variables.tf
@@ -4,6 +4,6 @@ variable "s3_logging_bucket_name" {
 variable "ec_test_instance_key_name" {
     type = "string"
 }
-variable "es_kinesis_delivery_stream" {
+variable "kinesis_delivery_stream" {
     default = "ElasticSearchKinesisDeliveryStream"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,9 +1,9 @@
 variable "s3_logging_bucket_name" {
     type = "string"
 }
-# variable "es_kinesis_delivery_stream" {
-#     type = "string"
-# }
+variable "kinesis_delivery_stream" {
+    type = "string"
+}
 variable "s3_kms_key_arn" {
     type = "string"
     description = "KMS Key ARN used to encrypt data within S3 bucket. The key must already exist within the account."

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,9 +1,9 @@
 variable "s3_logging_bucket_name" {
     type = "string"
 }
-variable "es_kinesis_delivery_stream" {
-    type = "string"
-}
+# variable "es_kinesis_delivery_stream" {
+#     type = "string"
+# }
 variable "s3_kms_key_arn" {
     type = "string"
     description = "KMS Key ARN used to encrypt data within S3 bucket. The key must already exist within the account."
@@ -12,48 +12,48 @@ variable "s3_kms_key_arn" {
 variable "aws_region" {
     default = "us-east-1"
 }
-variable "es_domain_name" {
-    default = "devsecops-ekk-stack"
-}
-variable "es_version" {
-    default = "1.5"
-}
-variable "es_instance_type" {
-    default = "t2.micro.elasticsearch"
-}
-variable "es_instance_count" {
-    default = "2"
-}
-variable "es_dedicated_master_instance_type" {
-    default = "t2.micro.elasticsearch"
-}
-variable "es_dedicated_master_count" {
-    default = "2"
-}
-variable "elasticsearch_role_name" {
-    default = "EKKElasticSearchRole"
-}
-variable "elasticsearch_role_policy_name" {
-    default = "EKKElasticSearchRolePolicy"
-}
+# variable "es_domain_name" {
+#     default = "devsecops-ekk-stack"
+# }
+# variable "es_version" {
+#     default = "1.5"
+# }
+# variable "es_instance_type" {
+#     default = "t2.micro.elasticsearch"
+# }
+# variable "es_instance_count" {
+#     default = "2"
+# }
+# variable "es_dedicated_master_instance_type" {
+#     default = "t2.micro.elasticsearch"
+# }
+# variable "es_dedicated_master_count" {
+#     default = "2"
+# }
+# variable "elasticsearch_role_name" {
+#     default = "EKKElasticSearchRole"
+# }
+# variable "elasticsearch_role_policy_name" {
+#     default = "EKKElasticSearchRolePolicy"
+# }
 variable "s3_delivery_role_name" {
     default = "EKKS3DeliveryRole"
 }
 variable "s3_role_log_bucket_access_policy" {
     default = "S3RoleBucketAccessPolicy"
 }
-variable "es_delivery_role_name" {
-    default = "ESDeliveryRole"
-}
-variable "es_log_group_name" {
-    default = "ElasticSearchDeliveryLogGroup"
-}
-variable "es_log_retention_in_days" {
-    default = "7"
-}
-variable "es_log_stream_name" {
-    default = "ElasticSearchDelivery"
-}
+# variable "es_delivery_role_name" {
+#     default = "ESDeliveryRole"
+# }
+# variable "es_log_group_name" {
+#     default = "ElasticSearchDeliveryLogGroup"
+# }
+# variable "es_log_retention_in_days" {
+#     default = "7"
+# }
+# variable "es_log_stream_name" {
+#     default = "ElasticSearchDelivery"
+# }
 variable "s3_log_group_name" {
     default = "S3DeliveryLogGroup"
 }
@@ -63,54 +63,54 @@ variable "s3_log_retention_in_days" {
 variable "s3_log_stream_name" {
     default = "S3Delivery"
 }
-variable "es_dedicated_master_enabled" {
-    default = "true"
-}
-variable "es_zone_awareness_enabled" {
-    default = "true"
-}
-variable "es_advanced_allow_explicit_index" {
-    default = "true"
-}
-variable "es_ebs_enabled" {
-    default = "true"
-}
-variable "es_ebs_iops" {
-    default = "0"
-}
-variable "es_ebs_volume_size" {
-    default = "20"
-}
-variable "es_ebs_volume_type" {
-    default = "gp2"
-}
-variable "es_snapshot_start_hour" {
-    default = "0"
-}
-variable "es_buffering_interval" {
-    default = "60"
-}
-variable "es_buffering_size" {
-    default = "50"
-}
-variable "es_cloudwatch_logging_enabled" {
-    default = "true"
-}
-variable "es_index_name" {
-    default = "logmonitor"
-}
-variable "es_type_name" {
-    default = "log"
-}
-variable "es_index_rotation_period" {
-    default = "NoRotation"
-}
-variable "es_retry_duration" {
-    default = "60"
-}
-variable "es_s3_backup_mode" {
-    default = "AllDocuments"
-}
+# variable "es_dedicated_master_enabled" {
+#     default = "true"
+# }
+# variable "es_zone_awareness_enabled" {
+#     default = "true"
+# }
+# variable "es_advanced_allow_explicit_index" {
+#     default = "true"
+# }
+# variable "es_ebs_enabled" {
+#     default = "true"
+# }
+# variable "es_ebs_iops" {
+#     default = "0"
+# }
+# variable "es_ebs_volume_size" {
+#     default = "20"
+# }
+# variable "es_ebs_volume_type" {
+#     default = "gp2"
+# }
+# variable "es_snapshot_start_hour" {
+#     default = "0"
+# }
+# variable "es_buffering_interval" {
+#     default = "60"
+# }
+# variable "es_buffering_size" {
+#     default = "50"
+# }
+# variable "es_cloudwatch_logging_enabled" {
+#     default = "true"
+# }
+# variable "es_index_name" {
+#     default = "logmonitor"
+# }
+# variable "es_type_name" {
+#     default = "log"
+# }
+# variable "es_index_rotation_period" {
+#     default = "NoRotation"
+# }
+# variable "es_retry_duration" {
+#     default = "60"
+# }
+# variable "es_s3_backup_mode" {
+#     default = "AllDocuments"
+# }
 variable "s3_buffer_size" {
     default = "10"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -30,12 +30,12 @@ variable "aws_region" {
 # variable "es_dedicated_master_count" {
 #     default = "2"
 # }
-# variable "elasticsearch_role_name" {
-#     default = "EKKElasticSearchRole"
-# }
-# variable "elasticsearch_role_policy_name" {
-#     default = "EKKElasticSearchRolePolicy"
-# }
+variable "ekk_role_name" {
+    default = "EKKRole"
+}
+variable "ekk_role_policy_name" {
+    default = "EKKRolePolicy"
+}
 variable "s3_delivery_role_name" {
     default = "EKKS3DeliveryRole"
 }


### PR DESCRIPTION
Temporarily removes Elasticsearch from the equation. Kinesis firehose only delivers to S3.